### PR TITLE
Get rid of `private` repository to not confuse students

### DIFF
--- a/assignments/containerization/assignment.md
+++ b/assignments/containerization/assignment.md
@@ -15,4 +15,4 @@ Your task is to build and run multi-container application using Docker.
 3. Create `Dockerfile` that will be used for building image of your application.
 4. Create `docker-compose.yml` file that will be used for running multi-container application (your application and `PostgreSQL` database). Specify custom network that will be used for communication between application and database containers.
 6. Build images and scan it for security vulnerabilities.
-7. Push built images to your private repository on `Docker Hub`.
+7. Push built images to your personal repositories on `Docker Hub`.


### PR DESCRIPTION
There are a huge number of frustrated students on Q42022 Node.js course, who do not understand (including myself) why it's stated to use private repository.

Let me try to explain:

- free tier gives only 1 private repo on Docker Hub
- we have 2 images to be pushed
- according to requirements, we need to push images to private repository. It's possible only in 2 cases 1) push both images to one repository by different tags, which is ideologically wrong 2) or buy a second private repo

----

To reduce the frustrating and confusion, it's suggested to reword and replace `private` with `personal`, so student can easily use public free personal repositories on their docker hub accounts.

Note: pushing to private or public repository has NO difference, that's why this change has no impact on the value of this task