### PR TITLE
fix: require usage of Streams API for calcHash.js task

### DIFF
--- a/assignments/nodejs-basics/assignment.md
+++ b/assignments/nodejs-basics/assignment.md
@@ -44,7 +44,7 @@ You should refactor file (you can add additional imports if needed)
 
 You should implement several functions in dedicated files
 
-- `calcHash.js` - implement function that calculates SHA256 hash for file `fileToCalculateHashFor.txt` and logs it into console as `hex`
+- `calcHash.js` - implement function that calculates SHA256 hash for file `fileToCalculateHashFor.txt` and logs it into console as `hex` using Streams API
 
 ### Streams (src/streams)
 


### PR DESCRIPTION
## fix: require usage of Streams API for calcHash.js task

- Added requirement to use Streams API for `calcHash.js` task. SHA256 hashes are often calculated for very large inputs.