### PR TITLE
feat(file-manager): add mkdir subtask

### DIFF
--- a/assignments/file-manager/assignment.md
+++ b/assignments/file-manager/assignment.md
@@ -61,6 +61,10 @@ List of operations and their syntax:
     ```bash
     add new_file_name
     ```
+    - Create new directory in current working directory: 
+    ```bash
+    mkdir new_directory_name
+    ```
     - Rename file (content should remain unchanged): 
     ```bash
     rn path_to_file new_filename

--- a/assignments/file-manager/score.md
+++ b/assignments/file-manager/score.md
@@ -12,7 +12,8 @@
     - **+20** List all files and folders in current directory
 - Basic operations with files implemented properly
     - **+10** Read file and print it's content in console
-    - **+10** Create empty file
+    - **+5** Create empty file
+    - **+5** Create new directory
     - **+10** Rename file
     - **+10** Copy file
     - **+10** Move file


### PR DESCRIPTION
While [discussing](https://discord.com/channels/755676888680366081/1201679239125155851/1203016342156877844) path handling, I noticed that our file manager lacks the ability to create a directory. 

This feature would be useful when testing an application on crosscheck.

Supposedly, our file manager is able to do **all the basic operations** except **this one**.

I haven't figured out what to do with the points, so I took some from `Create empty file` (probably not the best option)