### PR TITLE
Fix authentication assignment typo

### DIFF
--- a/assignments/logging-error-authentication-authorization/assignment.md
+++ b/assignments/logging-error-authentication-authorization/assignment.md
@@ -63,7 +63,7 @@ Your task is to implement Authentication and Authorization with JWT (Access and 
 
 3. **JWT** Access token should contain `userId` and `login` in a **payload** and has expiration time (expiration time of Refresh token should be longer, than Access token).
 
-4. The **JWT** Access token should be added in HTTP `Authorization` header to all requests that requires authentication. Proxy all the requests (except `auth/signup`, `auth/login`, `auth/refresh`, `/doc`, `/`) and check that HTTP `Authorization` header has the correct value of **JWT** Access token.  
+4. The **JWT** Access token should be added in HTTP `Authorization` header to all requests that requires authentication. Proxy all the requests (except `auth/signup`, `auth/login`, `/auth/refresh`, `/doc`, `/`) and check that HTTP `Authorization` header has the correct value of **JWT** Access token.  
 HTTP authentication must follow `Bearer` scheme:
   ```
   Authorization: Bearer <jwt_token>

--- a/assignments/logging-error-authentication-authorization/assignment.md
+++ b/assignments/logging-error-authentication-authorization/assignment.md
@@ -63,7 +63,7 @@ Your task is to implement Authentication and Authorization with JWT (Access and 
 
 3. **JWT** Access token should contain `userId` and `login` in a **payload** and has expiration time (expiration time of Refresh token should be longer, than Access token).
 
-4. The **JWT** Access token should be added in HTTP `Authorization` header to all requests that requires authentication. Proxy all the requests (except `auth/signup`, `auth/login`, `/doc`, `/`) and check that HTTP `Authorization` header has the correct value of **JWT** Access token.  
+4. The **JWT** Access token should be added in HTTP `Authorization` header to all requests that requires authentication. Proxy all the requests (except `auth/signup`, `auth/login`, `auth/refresh`, `/doc`, `/`) and check that HTTP `Authorization` header has the correct value of **JWT** Access token.  
 HTTP authentication must follow `Bearer` scheme:
   ```
   Authorization: Bearer <jwt_token>

--- a/assignments/logging-error-authentication-authorization/score.md
+++ b/assignments/logging-error-authentication-authorization/score.md
@@ -18,7 +18,7 @@
 - **+30** Route `/auth/login` has been implemented, related logic is divided between controller and corresponding service
 - **+10** `User` `password` saved into database as hash
 - **+20** Access Token is implemented,`JWT` payload contains `userId` and `login`, secret key is saved in `.env`.
-- **+40** Authentication is required for the access to all routes except `/auth/signup`, `/auth/login`, `auth/refresh`, `/doc` and `/`.
+- **+40** Authentication is required for the access to all routes except `/auth/signup`, `/auth/login`, `/auth/refresh`, `/doc` and `/`.
 - **+10** Separate module is implemented **within application scope** to check that all requests to all routes except mentioned above contain required JWT token
 
 ## Advanced Scope

--- a/assignments/logging-error-authentication-authorization/score.md
+++ b/assignments/logging-error-authentication-authorization/score.md
@@ -18,7 +18,7 @@
 - **+30** Route `/auth/login` has been implemented, related logic is divided between controller and corresponding service
 - **+10** `User` `password` saved into database as hash
 - **+20** Access Token is implemented,`JWT` payload contains `userId` and `login`, secret key is saved in `.env`.
-- **+40** Authentication is required for the access to all routes except `/auth/signup`, `/auth/login`, `/doc` and `/`.
+- **+40** Authentication is required for the access to all routes except `/auth/signup`, `/auth/login`, `auth/refresh`, `/doc` and `/`.
 - **+10** Separate module is implemented **within application scope** to check that all requests to all routes except mentioned above contain required JWT token
 
 ## Advanced Scope


### PR DESCRIPTION
The refresh token route should be public in the sense that it doesn't require access with an access token, because the access token has most likely already expired